### PR TITLE
Update p2-theme-core's version of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-uglify": "^1.5.1",
     "html-entities": "^1.2.0",
     "js-yaml": "^3.4.6",
-    "lodash": "^3.10.1",
+    "lodash": "^4.0.0",
     "main-bower-files": "^2.11.0",
     "mustache": "^2.2.1",
     "patternlab-node": "1.1.0",


### PR DESCRIPTION
<4.0.0 is deprecated, current version is 4.5.1 
