### PR TITLE
8: remove logic to move jQuery to top of bower devDependencies inject list

### DIFF
--- a/lib/pattern-lab--php-twig.js
+++ b/lib/pattern-lab--php-twig.js
@@ -16,7 +16,7 @@ module.exports = function (gulp, config, tasks) {
   var plPublic = path.join(plRoot, plConfig.publicDir);
   var plMeta = path.join(plSource, '/_meta');
   var consolePath = path.join(plRoot, 'core/console');
-  
+
   function plBuild(cb) {
     core.sh('php ' + consolePath +  ' --generate', true, function() {
       if (config.browserSync.enabled) {
@@ -25,9 +25,9 @@ module.exports = function (gulp, config, tasks) {
       cb();
     });
   }
-  
+
   gulp.task('pl', 'Compile Pattern Lab', plBuild);
-  
+
   var watchedExtensions = config.patternLab.watchedExtensions.join(',');
   gulp.task('watch:pl', function () {
     var plGlob = path.normalize(plSource + '/**/*.{' + watchedExtensions + '}' );
@@ -40,7 +40,7 @@ module.exports = function (gulp, config, tasks) {
       });
     });
   });
-  
+
   // Begin `<link>` & `<script>` injecting code.
   // Will look for these HTML comments in `plSource/_meta/*.twig:
   // `<!-- inject:css -->`
@@ -67,22 +67,6 @@ module.exports = function (gulp, config, tasks) {
     }
     sources = sources.concat(path.normalize(config.js.dest + '/*.js'));
     sources = sources.concat(path.normalize(config.css.dest + '/*.css'));
-    // if we have jQuery installed via Bower, we need to make sure it comes first
-    var jQueryPath;
-    sources = sources.filter(function(item) {
-      var file = item.split('/').pop();
-      if (file !== 'jquery.js') {
-        return true;
-      } else {
-        // here's jQuery, pulling it out of array for a sec
-        jQueryPath = item;
-        return false;
-      }
-    });
-    if (jQueryPath) {
-      // adds jQuery to first slot in array of sources
-      sources.unshift(jQueryPath);
-    }
 
     gulp.src([
       '*.twig'
@@ -99,21 +83,21 @@ module.exports = function (gulp, config, tasks) {
     .on('end', function() {
       done();
     });
-    
+
   });
-  
+
   if (config.patternLab.injectBower) {
     gulp.task('watch:inject:pl', function () {
       gulp.watch('./bower.json', ['inject:pl']);
     });
     tasks.watch.push('watch:inject:pl');
   }// end `if (config.patternLab.injectBower)`
-    
+
   var plFullDependencies = ['inject:pl'];
   if (config.icons.enabled) {
     plFullDependencies.push('icons');
   }
-  
+
   if (config.patternLab.scssToJson) {
     // turns scss files full of variables into json files that PL can iterate on
     gulp.task('pl:scss-to-json', function (done) {
@@ -129,35 +113,35 @@ module.exports = function (gulp, config, tasks) {
             value: x[1].replace(/;.*/, '').trim() // i.e. hsl(0, 0%, 50%)
           };
         });
-        
+
         if (! pair.allowVarValues) {
           varsAndValues = _.filter(varsAndValues, function(item) {
             return ! _.startsWith(item.value, '$');
           });
         }
-        
+
         fs.writeFileSync(pair.dest, JSON.stringify({
           items: varsAndValues,
           meta: {
-            description: 'To add to these items, use Sass variables that start with <code>' + pair.lineStartsWith + '</code> in <code>' + pair.src + '</code>' 
+            description: 'To add to these items, use Sass variables that start with <code>' + pair.lineStartsWith + '</code> in <code>' + pair.src + '</code>'
           }
         }, null, '  '));
-        
+
       });
       done();
     });
     plFullDependencies.push('pl:scss-to-json');
-    
+
     gulp.task('watch:pl:scss-to-json', function() {
       var files = config.patternLab.scssToJson.map(function(file) {return file.src;});
       gulp.watch(files, ['pl:scss-to-json']);
     });
     tasks.watch.push('watch:pl:scss-to-json');
   }
-  
+
   gulp.task('pl:full', false, plFullDependencies, plBuild);
-  
-  
+
+
   tasks.watch.push('watch:pl');
   tasks.compile.push('pl:full');
 


### PR DESCRIPTION
I just removed the logic to move jQuery to the top of the js injection list. The order of bower devDepencencies easily does this for us.
