### PR TITLE
Allow iconfont timestamp to be configured

### DIFF
--- a/config.default.yml
+++ b/config.default.yml
@@ -67,6 +67,7 @@ icons: # https://github.com/nfroidure/gulp-iconfont
   classNamePrefix: icon
   autohint: false
   normalize: true
+  timestamp: runTimestamp
   templates:
     enabled: true
     css:

--- a/lib/icons.js
+++ b/lib/icons.js
@@ -18,7 +18,7 @@ module.exports = function (gulp, config, tasks) {
           fontName: iconName,
           appendUniconde: true,
           formats: config.icons.formats,
-          timestamp: runTimestamp,
+          timestamp: config.icons.timestamp,
           autohint: config.icons.autohint,
           normalize: config.icons.normalize
         }));


### PR DESCRIPTION
This is a minor thing, but was driving me crazy. The generated icon fonts have a timestamp embedded, which means that the files show up as changed on every build/deploy.

This PR allows me to set the timestamp to 0 in my config so that the files stay the same unless I actually make changes.

See: https://github.com/nfroidure/gulp-iconfont/issues/70
