### PR TITLE
Drupal inject update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 
 tests/css/dest/
+
+.idea

--- a/config.default.yml
+++ b/config.default.yml
@@ -109,5 +109,6 @@ drupal:
   # in this directory
   dir: ./
   inject:
+    enabled: true
     bower: true
     file: theme.info

--- a/config.default.yml
+++ b/config.default.yml
@@ -108,7 +108,6 @@ drupal:
   command: drush cc all
   # in this directory
   dir: ./
-  inject:
-    enabled: true
+  inject: # set false here and comment out below to disable asset injection into Drupal, eg `inject: false`
     bower: true
     file: theme.info

--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -66,7 +66,7 @@ module.exports = function(gulp, config, tasks) {
 
   injectDrupal.description = 'Inject dependencies into Drupal 7 theme files.';
 
-  if (config.drupal.inject) {
+  if (config.drupal.inject.enabled) {
     // if CSS & JS compiling, ensure it's done before we inject Drupal
     var injectDeps = [];
     if (config.css.enabled) {

--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -66,7 +66,7 @@ module.exports = function(gulp, config, tasks) {
 
   injectDrupal.description = 'Inject dependencies into Drupal 7 theme files.';
 
-  if (config.drupal.inject.enabled) {
+  if (config.drupal.inject) {
     // if CSS & JS compiling, ensure it's done before we inject Drupal
     var injectDeps = [];
     if (config.css.enabled) {


### PR DESCRIPTION
./lib/drupal.js was checking against config.drupal.inject before configuring drupal injection. It wasn't clear to me to set `inject: false` while also commenting out children below `inject` to disable, so I added a comment.

This is in my pursuit to prevent the multiple asynchronous css:full compile tasks that run on startup. This is actually causing side effects as 3+ css compile tasks all manipulate and post-process the same files. See: https://github.com/phase2/p2-theme-core/issues/12
