### PR TITLE
[HOLD] Prevent dependency tasks firing reduntantly by introducing a 'startup' concept to p2-theme-core

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ module.exports = function (gulp, config, tasks) {
   var defaultConfig = yaml.safeLoad(fs.readFileSync(__dirname + '/config.default.yml', 'utf8'));
   config = _.merge(defaultConfig, config);
 
+  require('./lib/startup').gulpTask(gulp, config, tasks);
+
   if (config.browserSync.enabled) {
     require('./lib/browser-sync.js')(gulp, config, tasks);
   }

--- a/lib/css.js
+++ b/lib/css.js
@@ -15,6 +15,10 @@ var join = require('path').join;
 var del = require('del');
 //var debug = require('gulp-debug');
 
+// Startup check to avoid multiple dependency runs
+var isStartup = require('./startup').isStartup;
+var ranOnce = false;
+
 module.exports = function (gulp, config, tasks) {
 
   function cssCompile(done, errorShouldExit) {
@@ -131,7 +135,14 @@ module.exports = function (gulp, config, tasks) {
   }
 
   gulp.task('css:full', gulp.series(cssDeps, function cssFull(done) {
+    // This task should only run once on startup, no matter the dependency
+    if (isStartup() && ranOnce)  {
+      console.info('Task css:full called multiple times on startup as dependency of other tasks. Deferring.');
+      done();
+      return;
+    }
     cssCompile(done, true);
+    ranOnce = true;
   }));
   tasks.compile.push('css:full');
 

--- a/lib/icons.js
+++ b/lib/icons.js
@@ -5,6 +5,10 @@ var del = require('del');
 var _ = require('lodash');
 var runTimestamp = Math.round(Date.now() / 1000);
 
+// Startup check to avoid multiple dependency runs
+var isStartup = require('./startup').isStartup;
+var ranOnce = false;
+
 module.exports = function (gulp, config, tasks) {
   var iconName = 'icons'; // @todo make configurable
   // Use custom template delimiters of `{{` and `}}`.
@@ -62,7 +66,16 @@ module.exports = function (gulp, config, tasks) {
 
   icons.description = 'Build font icons from SVG files';
 
-  gulp.task('icons', icons);
+  gulp.task('icons', function fullIcons(done) {
+    // This task should only run once on startup, no matter the dependency
+    if (isStartup() && ranOnce)  {
+      console.info('Task icons called multiple times on startup as dependency of other tasks. Deferring.');
+      done();
+      return;
+    }
+    icons(done);
+    ranOnce = true;
+  });
 
   function watchIcons() {
     var src = [config.icons.src];

--- a/lib/js.js
+++ b/lib/js.js
@@ -8,6 +8,10 @@ var cached = require('gulp-cached');
 var gulpif = require('gulp-if');
 var del = require('del');
 
+// Startup check to avoid multiple dependency runs
+var isStartup = require('./startup').isStartup;
+var ranOnce = false;
+
 module.exports = function (gulp, config, tasks) {
 
   config.js.dest = config.js.dest || config.js.destDir;
@@ -43,7 +47,16 @@ module.exports = function (gulp, config, tasks) {
 
   compileJs.description = 'Transpile JS using Babel, concat and uglify.';
 
-  gulp.task('js', compileJs);
+  gulp.task('js', function fullCompileJs(done) {
+    // This task should only run once on startup, no matter the dependency
+    if (isStartup() && ranOnce)  {
+      console.info('Task js called multiple times on startup as dependency of other tasks. Deferring.');
+      done();
+      return;
+    }
+    compileJs(done);
+    ranOnce = true;
+  });
 
   gulp.task('watch:js', function () {
     return gulp.watch(config.js.src, gulp.parallel(

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,0 +1,17 @@
+var startup = false;
+
+module.exports = {
+  gulpTask: function (gulp, config, tasks) {
+    gulp.task('startup:start', function startupStart(cb) {
+      startup = true;
+      cb();
+    });
+    gulp.task('startup:stop', function startupStop(cb) {
+      startup = false;
+      cb();
+    });
+  },
+  isStartup: function() {
+    return startup;
+  }
+};


### PR DESCRIPTION
All this change introduces is a concept of `startup:start` and `startup:stop` tasks. Tasks that may be dependencies of multiple other tasks simply ask:
1. Are we in the startup phase?
2. Have I run already at all?

At the [pattern-lab-starter](https://github.com/phase2/pattern-lab-starter) level is the modification to the `default` task in `gulpfile.js` like so:

``` javascript
gulp.task('default', gulp.series(
  'startup:start',
  'compile',
  gulp.parallel(tasks.default),
  'startup:stop'
));
```

PR to pattern-lab-starter repo here: https://github.com/phase2/pattern-lab-starter/pull/55
