### PR TITLE
refactoring icon template approach

### DIFF
--- a/lib/icons.js
+++ b/lib/icons.js
@@ -1,19 +1,24 @@
 'use strict';
 const iconfont = require('gulp-iconfont');
-const consolidate = require('gulp-consolidate');
 const del = require('del');
 const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
 const browserSync = require('browser-sync');
 
 const runTimestamp = Math.round(Date.now() / 1000);
 
 module.exports = (gulp, config, tasks) => {
-  const iconName = 'icons'; // @todo make configurable
+  const iconName = config.icons.iconName || 'icons';
   // Use custom template delimiters of `{{` and `}}`.
   _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
   // Use custom evaluate delimiters of `{%` and `%}`.
   _.templateSettings.evaluate = /{%([\s\S]+?)%}/g;
 
+  /**
+   * Build font icons from SVG files and optionally make scss and demo templates.
+   * @param done {function} - Callback when all done.
+   */
   function icons(done) {
     const stream = gulp.src(config.icons.src)
       .pipe(iconfont({
@@ -30,40 +35,40 @@ module.exports = (gulp, config, tasks) => {
     }
     if (config.icons.templates.enabled) {
       stream.on('glyphs', (glyphs) => {
-        // console.log(glyphs, options);
-        gulp.src(config.icons.templates.css.src)
-          .pipe(consolidate('lodash', {
-            glyphs: glyphs.map((glyph) => {
-              const glyphUnicode = glyph.unicode[0].toString(16).toUpperCase();
-              return {
-                name: glyph.name,
-                content: glyphUnicode,
-              };
-            }),
-            fontName: iconName,
-            fontPath: config.icons.fontPathPrefix,
-            classNamePrefix: config.icons.classNamePrefix,
-          }))
-          .pipe(gulp.dest(config.icons.templates.css.dest))
-          .on('end', () => {
-            gulp.src(config.icons.templates.demo.src)
-              .pipe(consolidate('lodash', {
-                glyphs: glyphs.map((glyph) => {
-                  const glyphUnicode = glyph.unicode[0].toString(16).toUpperCase();
-                  return {
-                    name: glyph.name,
-                    content: glyphUnicode,
-                  };
-                }),
-                fontName: iconName,
-                fontPath: config.icons.fontPathPrefix,
-                classNamePrefix: config.icons.classNamePrefix,
-              }))
-              .pipe(gulp.dest(config.icons.templates.demo.dest))
-              .on('end', () => {
-                done();
-              });
+        // console.log(glyphs);
+        const iconData = {
+          glyphs: glyphs.map((glyph) => {
+            return {
+              name: glyph.name,
+              content: glyph.unicode[0].toString(16).toUpperCase(),
+            };
+          }),
+          fontName: iconName,
+          fontPath: config.icons.fontPathPrefix,
+          classNamePrefix: config.icons.classNamePrefix,
+        };
+
+        /**
+         * Process Icon Templates
+         * @param srcFile {string} - Path to lodash template file.
+         * @param destDir {string} - Path to write processed file to.
+         * @param done {function} - Callback for when done.
+         */
+        function processIconTemplate(srcFile, destDir, done) {
+          fs.readFile(srcFile, 'utf8', (err, srcFileContents) => {
+            if (err) throw err;
+            const result = _.template(srcFileContents)(iconData);
+            const destFile = path.join(destDir, path.basename(srcFile));
+            fs.writeFile(destFile, result, done);
           });
+        }
+
+        // Process sass template
+        processIconTemplate(config.icons.templates.css.src, config.icons.templates.css.dest, () => {
+          // Then process demo (twig) template. Then say we are `done()`
+          processIconTemplate(config.icons.templates.demo.src, config.icons.templates.demo.dest, done);
+        });
+
       });
     } else {
       done();
@@ -88,7 +93,7 @@ module.exports = (gulp, config, tasks) => {
   gulp.task('watch:icons', watchIcons);
 
   function cleanIcons(done) {
-    const toClean = [`${config.icons.dest}${iconName}.*`];
+    const toClean = [path.join(config.icons.dest, `${iconName}.*`)];
 
     if (config.icons.templates.enabled) {
       const cssTemplateFilename = _.last(config.icons.templates.css.src.split('/'));

--- a/lib/icons.js
+++ b/lib/icons.js
@@ -37,12 +37,10 @@ module.exports = (gulp, config, tasks) => {
       stream.on('glyphs', (glyphs) => {
         // console.log(glyphs);
         const iconData = {
-          glyphs: glyphs.map((glyph) => {
-            return {
-              name: glyph.name,
-              content: glyph.unicode[0].toString(16).toUpperCase(),
-            };
-          }),
+          glyphs: glyphs.map(glyph => ({ // returns the object
+            name: glyph.name,
+            content: glyph.unicode[0].toString(16).toUpperCase(),
+          })),
           fontName: iconName,
           fontPath: config.icons.fontPathPrefix,
           classNamePrefix: config.icons.classNamePrefix,
@@ -52,23 +50,26 @@ module.exports = (gulp, config, tasks) => {
          * Process Icon Templates
          * @param srcFile {string} - Path to lodash template file.
          * @param destDir {string} - Path to write processed file to.
-         * @param done {function} - Callback for when done.
+         * @param cb {function} - Callback for when done.
          */
-        function processIconTemplate(srcFile, destDir, done) {
+        function processIconTemplate(srcFile, destDir, cb) {
           fs.readFile(srcFile, 'utf8', (err, srcFileContents) => {
             if (err) throw err;
             const result = _.template(srcFileContents)(iconData);
             const destFile = path.join(destDir, path.basename(srcFile));
-            fs.writeFile(destFile, result, done);
+            fs.writeFile(destFile, result, cb);
           });
         }
 
         // Process sass template
         processIconTemplate(config.icons.templates.css.src, config.icons.templates.css.dest, () => {
           // Then process demo (twig) template. Then say we are `done()`
-          processIconTemplate(config.icons.templates.demo.src, config.icons.templates.demo.dest, done);
+          processIconTemplate(
+            config.icons.templates.demo.src,
+            config.icons.templates.demo.dest,
+            done
+          );
         });
-
       });
     } else {
       done();

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "gulp-babel": "^6.1.1",
     "gulp-cached": "^1.1.0",
     "gulp-concat": "^2.6.0",
-    "gulp-consolidate": "^0.2.0",
     "gulp-eslint": "^3.0.1",
     "gulp-flatten": "^0.2.0",
     "gulp-iconfont": "^8.0.0",


### PR DESCRIPTION
This ditches using `gulp-consolidate` using lodash templates to just using lodash templates to help with a conflict I had when using this alongside other projects. It also takes a step forward in my reduce dependencies initiative. This PR is going right into our feature/es-awesome branch, mainly for visibility for @illepic to see the changes. I'll probably merge this in later today, but if you get a chance to pull and test, that'd be sweet. If you test: remember icon compiling hasn't changed, just the template (icons.scss and icons.twig) compile method. 

Related: I improved how the icons sass is set up in PL Starter too: https://github.com/phase2/pattern-lab-starter/commit/c03506f1fb1c66cfac6cf650b661c9e7b260585b
