### PR TITLE
browser-sync rewriterules must be an empty array

### DIFF
--- a/lib/browser-sync.js
+++ b/lib/browser-sync.js
@@ -23,7 +23,7 @@ module.exports = (gulp, config, tasks) => {
     reloadDelay: config.browserSync.reloadDelay,
     reloadDebounce: config.browserSync.reloadDebounce,
     // https://www.browsersync.io/docs/options#option-rewriteRules
-    rewriteRules: config.browserSync.rewriteRules || false,
+    rewriteRules: config.browserSync.rewriteRules || [],
     // placing at `</body>` instead of `<body>`
     snippetOptions: {
       rule: {


### PR DESCRIPTION
browserync calls `.forEach()` against this.
