### PR TITLE
Feature/css sourcemap clarification

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     // enables additional debugging information in the output file as CSS comments - only use when necessary
     sourceComments: false,
-    sourceMapEmbed: false,
+    sourceMap: false,
     // tell the compiler whether you want 'expanded' or 'compressed' output code
     outputStyle: 'expanded',
     // https://github.com/ai/browserslist#queries

--- a/lib/css.js
+++ b/lib/css.js
@@ -44,7 +44,7 @@ module.exports = (gulp, config, tasks) => {
         }),
       ]
     ))
-    .pipe(sourcemaps.write((config.css.sourceMapEmbed) ? null : './'))
+    .pipe(sourcemaps.write((config.css.sourceMap) ? './' : null))
     .pipe(gulpif(config.css.flattenDestOutput, flatten()))
     .pipe(gulp.dest(config.css.dest))
     .on('end', () => {


### PR DESCRIPTION
The relationship between the boolean for config.css.sourceMapEmbed and it behaviour was confusing to me. A 'false' value in the config caused the writing of a style.css.map file after sass compiling, while a 'true' value lead to the .map file being dumped. I switched it so 'true' writes the file and 'false' omits it. 
I also removed the term "embed" from the property name, as I don't think it was clear or needed.