### PR TITLE
eliminates drupal.js dependency on browsersync

### DIFF
--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -5,7 +5,9 @@ const browserSync = require('browser-sync');
 module.exports = (gulp, config, tasks) => {
   function clearDrupalCache(done) {
     core.sh(`cd ${config.drupal.dir} && ${config.drupal.command}`, true, () => {
-      browserSync.get('server').reload();
+      if (config.browserSync.enabled) {
+        browserSync.get('server').reload();
+      }
       done();
     });
   }


### PR DESCRIPTION
Looks like other features (icons, js, etc) have conditionals to skip browsersync reloading when it is not enabled. This adds the same to the drupal.js where it was missing.

PS. Thanks for all the work on this and the patternlab starter. 