### PR TITLE
Default tasks to avoid empty series/parallel

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-'use strict';
 const _ = require('lodash');
 const defaultConfig = require('./config.default');
 
@@ -41,6 +40,21 @@ module.exports = (gulp, userConfig, tasks) => {
   // We basically need icons compiled before CSS & CSS/JS compiled before inject:pl before pl
   // compile. The order of the `require`s above is the order that compiles run in; not perfect, but
   // it works.
+
+  // Users can potentially disable all tasks. This will leave empty task arrays
+  // which causes Gulp to kersplode. Add at least one dummy task to the array if
+  // it is otherwise empty
+  // The major types are: compile, watch, validate, clean, default
+  _.forEach(tasks, (value, key) => {
+    if (tasks[key].length === 0) {
+      // Create a fake task that just signals completion via callback
+      gulp.task(`${key} fallback task`, (cb) => { cb(); });
+      // Add it on if otherwise empty
+      tasks[key].push(`${key} fallback task`);
+    }
+  });
+
+
   // eslint-disable-next-line no-param-reassign
   tasks.compile = gulp.series(tasks.compile);
 };

--- a/lib/js.js
+++ b/lib/js.js
@@ -48,7 +48,9 @@ module.exports = (gulp, config, tasks) => {
 
   gulp.task('js', compileJs);
 
-  gulp.task('watch:js', () => gulp.watch(config.js.src, compileJs));
+  gulp.task('watch:js', () => {
+    gulp.watch(config.js.src, compileJs);
+  });
 
   gulp.task('clean:js', (done) => {
     del([


### PR DESCRIPTION
Provide default tasks so we can selectively disable p2-theme-core features without errors.