### PR TITLE
rewrote gulp watch functions to include watch.options from config

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -1,4 +1,11 @@
 module.exports = {
+  watch: {
+    options: {
+      // Uncomment 2 lines below to allow polling which necessary to run gulp-watch in a docker container on windows.
+      // interval: 1000, 
+      // usePolling: true,
+    }
+  },
   css: {
     enabled: true,
     src: [

--- a/lib/css.js
+++ b/lib/css.js
@@ -116,7 +116,7 @@ module.exports = (gulp, config, tasks) => {
     const src = config.css.extraWatches
       ? [].concat(config.css.src, config.css.extraWatches)
       : config.css.src;
-    return gulp.watch(src, gulp.parallel(watchTasks));
+    return gulp.watch(src, config.watch.options, gulp.parallel(watchTasks));
   }
 
   watchCss.description = 'Watch Scss';

--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -17,7 +17,7 @@ module.exports = (gulp, config, tasks) => {
   gulp.task('cc', clearDrupalCache);
 
   gulp.task('watch:drupal', () => {
-    gulp.watch(config.drupal.watch, clearDrupalCache);
+    gulp.watch(config.drupal.watch, config.watch.options, clearDrupalCache);
   });
   tasks.watch.push('watch:drupal');
 };

--- a/lib/icons.js
+++ b/lib/icons.js
@@ -86,7 +86,7 @@ module.exports = (gulp, config, tasks) => {
       src.push(config.icons.templates.css.src);
       src.push(config.icons.templates.demo.src);
     }
-    return gulp.watch(src, icons);
+    return gulp.watch(src, config.watch.options, icons);
   }
 
   watchIcons.description = 'Watch icons';

--- a/lib/js.js
+++ b/lib/js.js
@@ -24,7 +24,7 @@ module.exports = (gulp, config, tasks) => {
   if (config.js.eslint.enabled) {
     gulp.task('validate:js', () => validateJs().pipe(eslint.failAfterError()));
     tasks.validate.push('validate:js');
-    gulp.task('watch:validate:js', () => gulp.watch(config.js.eslint.src, validateJs));
+    gulp.task('watch:validate:js', () => gulp.watch(config.js.eslint.src, config.watch.options, validateJs));
     tasks.watch.push('watch:validate:js');
   }
 
@@ -48,7 +48,7 @@ module.exports = (gulp, config, tasks) => {
 
   gulp.task('js', compileJs);
 
-  gulp.task('watch:js', () => gulp.watch(config.js.src, compileJs));
+  gulp.task('watch:js', () => gulp.watch(config.js.src, config.watch.options, compileJs));
 
   gulp.task('clean:js', (done) => {
     del([
@@ -104,7 +104,7 @@ module.exports = (gulp, config, tasks) => {
     // @todo remove `config.patternLab.bowerBasePath` in v10.0.0
     const bowerBasePath = config.js.bowerBasePath || config.patternLab.bowerBasePath || './';
     gulp.task('watch:bower', () => {
-      gulp.watch(path.join(bowerBasePath, 'bower.json'), gulp.series('js:bundleBower'));
+      gulp.watch(path.join(bowerBasePath, 'bower.json'), config.watch.options, gulp.series('js:bundleBower'));
     });
     tasks.compile.push('js:bundleBower');
     tasks.watch.push('watch:bower');

--- a/lib/pattern-lab--php-twig.js
+++ b/lib/pattern-lab--php-twig.js
@@ -109,7 +109,7 @@ module.exports = (gulp, config, tasks) => {
 
     gulp.task('watch:pl:scss-to-json', () => {
       const files = config.patternLab.scssToJson.map(file => file.src);
-      gulp.watch(files, scssToJson);
+      gulp.watch(files, config.watch.options, scssToJson);
     });
     tasks.watch.push('watch:pl:scss-to-json');
   }
@@ -190,7 +190,7 @@ module.exports = (gulp, config, tasks) => {
       : plGlob;
     // plBuild goes last after any deps
     watchTriggeredTasks.push(plBuild);
-    gulp.watch(src, gulp.series(watchTriggeredTasks));
+    gulp.watch(src, config.watch.options, gulp.series(watchTriggeredTasks));
   });
 
   tasks.watch.push('watch:pl');


### PR DESCRIPTION
I'm a dirty Windows user and have to run node / gulp from within a docker node container so things work as they should. Except for gulp watch. I modified the config and watch functions to allow polling for users like me.