### PR TITLE
Require a version of gulp that exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4097,13 +4097,12 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "gulp": {
-      "version": "github:gulpjs/gulp#6d71a658c61edb3090221579d8f97dbe086ba2ed",
-      "from": "github:gulpjs/gulp#6d71a65",
+      "version": "github:gulpjs/gulp#89acc5c17e115ec03ec6b17341c3ffdf5e2db837",
       "requires": {
-        "glob-watcher": "^3.0.0",
-        "gulp-cli": "^1.0.0",
-        "undertaker": "^1.0.0",
-        "vinyl-fs": "^2.0.0"
+        "glob-watcher": "3.2.0",
+        "gulp-cli": "1.4.0",
+        "undertaker": "1.2.0",
+        "vinyl-fs": "2.4.4"
       },
       "dependencies": {
         "camelcase": {
@@ -4116,38 +4115,38 @@
           "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-1.4.0.tgz",
           "integrity": "sha1-b1u+LNC9tISdEs+eEkalhh+LT4g=",
           "requires": {
-            "archy": "^1.0.0",
-            "chalk": "^1.1.0",
-            "copy-props": "^1.4.1",
-            "fancy-log": "^1.1.0",
-            "gulplog": "^1.0.0",
-            "interpret": "^1.0.0",
-            "liftoff": "^2.3.0",
-            "lodash.isfunction": "^3.0.8",
-            "lodash.isplainobject": "^4.0.4",
-            "lodash.sortby": "^4.5.0",
-            "matchdep": "^1.0.0",
-            "mute-stdout": "^1.0.0",
-            "pretty-hrtime": "^1.0.0",
-            "semver-greatest-satisfied-range": "^1.0.0",
-            "tildify": "^1.0.0",
-            "v8flags": "^2.0.9",
-            "wreck": "^6.3.0",
-            "yargs": "^3.28.0"
+            "archy": "1.0.0",
+            "chalk": "1.1.3",
+            "copy-props": "1.6.0",
+            "fancy-log": "1.3.0",
+            "gulplog": "1.0.0",
+            "interpret": "1.0.3",
+            "liftoff": "2.5.0",
+            "lodash.isfunction": "3.0.9",
+            "lodash.isplainobject": "4.0.6",
+            "lodash.sortby": "4.7.0",
+            "matchdep": "1.0.1",
+            "mute-stdout": "1.0.0",
+            "pretty-hrtime": "1.0.3",
+            "semver-greatest-satisfied-range": "1.1.0",
+            "tildify": "1.2.0",
+            "v8flags": "2.1.1",
+            "wreck": "6.3.0",
+            "yargs": "3.32.0"
           }
         },
         "yargs": {
           "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.1",
     "eslint-plugin-react": "^6.2.0",
     "glob": "^7.1.1",
-    "gulp": "github:gulpjs/gulp#6d71a65",
+    "gulp": "github:gulpjs/gulp#89acc5c",
     "gulp-babel": "^6.1.3",
     "gulp-cached": "^1.1.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
I believe that the maintainers of gulp rewrote the history of the repo.
After comparing these:

https://github.com/gulpjs/gulp/commit/6d71a658c61edb3090221579d8f97dbe086ba2ed
https://github.com/gulpjs/gulp/commit/89acc5c17e115ec03ec6b17341c3ffdf5e2db837

I replaced the version 6d71a65 (which no longer exists in the
repository) with 89acc5c. I then updated the lock file, changing as
little as possible.